### PR TITLE
chore(deps): add dependabot config with grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"
+    groups:
+      # All updates, major included, in a single PR.
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly updates, one grouped PR per ecosystem (major bumps included), matching the pattern used across the other repos.